### PR TITLE
Made the context menu highlight context as the active li item, and added...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,9 @@ and you probably want to omit the label setting. The breadrumbs may in this
 usage be deemed redundant. If so, override Kotti's master template to omit it
 (See below, under discussion of display_type).
 
+The default development.ini config file has a tree nav in the left slot. See
+the alternate top.ini for an example of a configuration replacing nav.pt.
+
 Excluding the Root
 ------------------
 

--- a/kotti_navigation/__init__.py
+++ b/kotti_navigation/__init__.py
@@ -51,6 +51,8 @@ def kotti_configure(settings):
 
     settings['pyramid.includes'] += ' {0}'.format(nav_widget_directive)
 
+    if 'kotti_navigation.widget.slot' in settings:
+        assign_slot('recent_news', settings['kotti_newsitem.widget.slot'])
 
 def include_view(config):
 

--- a/kotti_navigation/templates/navigation.pt
+++ b/kotti_navigation/templates/navigation.pt
@@ -58,11 +58,22 @@
           <li tal:condition="lineage_items" class="nav-header">
             You are here:
           </li>
-          <li tal:repeat="cmi lineage_items">
-            <a href="${api.url(cmi)}"
-               style="padding-left: ${(repeat.cmi.index + 1) + 1}em;"
-               title="${getattr(cmi, 'description', None)}">
-              ${cmi.title}
+          <tal:block repeat="lineage_item lineage_items">
+            <li tal:define="active lineage_item==context and 'active' or '';
+                            hidden not lineage_item.in_navigation and 'hidden' or ''"
+                class="${active} ${hidden}">
+              <a href="${api.url(lineage_item)}"
+                 style="padding-left: ${(repeat.lineage_item.index + 1) + 1}em;"
+                 title="${getattr(lineage_item, 'description', None)}">
+                ${lineage_item.title}
+              </a>
+            </li>
+          </tal:block>
+          <li tal:repeat="child items">
+            <a href="${api.url(child)}"
+               style="padding-left: ${len(lineage_items) + 2}em;"
+               title="${getattr(child, 'description', None)}">
+              ${child.title}
             </a>
           </li>
         </ul>
@@ -113,9 +124,9 @@
                tal:condition="(children and slot in ['left', 'right'])
                               or (children and not show_dropdown_menus)
                               or not children">
-        <li class="${active} ${hidden}"
-            tal:define="active item == context and 'active' or '';
-            hidden not item.in_navigation and 'hidden' or ''">
+        <li tal:define="active item == context and 'active' or '';
+                        hidden not item.in_navigation and 'hidden' or ''"
+            class="${active} ${hidden}">
           <a href="${api.url(item)}"
              title="${getattr(item, 'description', None)}">
             ${item.title}

--- a/kotti_navigation/views.py
+++ b/kotti_navigation/views.py
@@ -148,9 +148,18 @@ def navigation_widget(context, request, name=''):
         ac = get_children(item, request)
         allowed_children.append(ac if ac else [])
 
+    # The lineage function of pyramid is used to make a breadcrumbs-style
+    # display for the context menu.
     lineage_items = get_lineage(context, request)
     if not include_root:
         lineage_items.remove(root)
+
+    # The lineage comes back in root-last order, so reverse.
+    lineage_items.reverse()
+
+    # The lineage (breadcrumbs style) display in navigation.pt shows
+    # lineage_items in an indented dropdown list, and below that has a li
+    # repeat on items, indented beneath context.
 
     return {'root': root,
             'slot': slot,
@@ -160,7 +169,7 @@ def navigation_widget(context, request, name=''):
             'items': items,
             'show_context_menu': show_context_menu,
             'top_level_items': top_level_items,
-            'lineage_items': reversed(lineage_items),
+            'lineage_items': lineage_items,
             'allowed_children': allowed_children,
             'label': label,
             'show_dropdown_menus': show_dropdown_menus,

--- a/top.ini
+++ b/top.ini
@@ -1,0 +1,85 @@
+[app:kotti]
+use = egg:kotti
+
+pyramid.reload_templates = true
+pyramid.debug_templates = true
+pyramid.debug_authorization = false
+pyramid.debug_notfound = false
+pyramid.debug_routematch = false
+pyramid.default_locale_name = en
+pyramid.includes =
+     pyramid_tm
+     pyramid_debugtoolbar
+
+sqlalchemy.url = sqlite:///%(here)s/Kotti.db
+#mail.default_sender = yourname@yourhost
+
+kotti.site_title = My Kotti site
+kotti.asset_overrides = kotti_navigation:kotti-overrides/
+kotti.secret = qwerty
+
+kotti.configurators =
+    kotti_tinymce.kotti_configure
+    kotti_navigation.kotti_configure
+
+kotti_navigation.navigation_widget.include_root = true
+kotti_navigation.navigation_widget.display_type = list
+kotti_navigation.navigation_widget.show_context_menu = true
+kotti_navigation.navigation_widget.label = context:
+kotti_navigation.navigation_widget.slot = none
+kotti_navigation.navigation_widget.open_all = false
+kotti_navigation.navigation_widget.show_hidden_while_logged_in = true
+kotti_navigation.navigation_widget.exclude_content_types =
+    kotti.resources.Image
+
+[filter:fanstatic]
+use = egg:fanstatic#fanstatic
+
+[pipeline:main]
+pipeline =
+    fanstatic
+    kotti
+
+[server:main]
+use = egg:waitress#main
+host = 127.0.0.1
+port = 5000
+
+# Begin logging configuration
+
+[loggers]
+keys = root, kotti, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_kotti]
+level = DEBUG
+handlers =
+qualname = kotti
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARN" logs neither.  (Recommended for production systems.)
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
+
+# End logging configuration


### PR DESCRIPTION
... a li repeat to show children of context, indented below the highlighted context in the lineage (breadcrumbs style) display. This more complete display matches what is shown in the list item display, and provides a more useful, hyrid breadcrumbs style display. In an unrelated bit, fixed the order of tal:defines to come before the class setting in the bottom repeat in navigation.pt.
