### PR TITLE
Fix #12: c.__class__ => c.__class__.__name__

### DIFF
--- a/kotti_navigation/views.py
+++ b/kotti_navigation/views.py
@@ -20,10 +20,10 @@ def get_children(context, request):
 
     if show_hidden and user:
         children = [c for c in context.children_with_permission(request)
-                    if c.__class__ not in ex_cts]
+                    if c.__class__.__name__ not in ex_cts]
     else:
         children = [c for c in context.children_with_permission(request)
-                    if c.in_navigation and c.__class__ not in ex_cts]
+                    if c.in_navigation and c.__class__.__name__ not in ex_cts]
 
     return children
 
@@ -37,10 +37,10 @@ def get_lineage(context, request):
 
     if show_hidden and user:
         items = [item for item in list(lineage(context))
-                 if item.__class__ not in ex_cts]
+                 if item.__class__.__name__ not in ex_cts]
     else:
         items = [item for item in list(lineage(context))
-                 if item.in_navigation and item.__class__ not in ex_cts]
+                 if item.in_navigation and item.__class__.__name__ not in ex_cts]
 
     return items
 


### PR DESCRIPTION
Prevents the error in #12:

```pytb
  File "/Users/marca/python/virtualenvs/kotti_inventorysvc/lib/python2.7/site-packages/chameleon/py26.py", line 5, in lookup_attr
    return getattr(obj, key)
  File "/Users/marca/dev/git-repos/Kotti/kotti/views/util.py", line 101, in __getattr__
    for snippet in objectevent_listeners(event):
  File "/Users/marca/dev/git-repos/Kotti/kotti/events.py", line 169, in __call__
    results.append(handler(event))
  File "/Users/marca/dev/git-repos/Kotti/kotti/views/slots.py", line 105, in <lambda>
    lambda ev: _render_view_on_slot_event(view_name, ev, params))
  File "/Users/marca/dev/git-repos/Kotti/kotti/views/slots.py", line 79, in _render_view_on_slot_event
    result = render_view(context, view_request, view_name)
  File "/Users/marca/dev/git-repos/pyramid/pyramid/view.py", line 114, in render_view
    iterable = render_view_to_iterable(context, request, name, secure)
  File "/Users/marca/dev/git-repos/pyramid/pyramid/view.py", line 87, in render_view_to_iterable
    response = render_view_to_response(context, request, name, secure)
  File "/Users/marca/dev/git-repos/pyramid/pyramid/view.py", line 60, in render_view_to_response
    return view(context, request)
  File "/Users/marca/dev/git-repos/pyramid/pyramid/config/views.py", line 352, in rendered_view
    result = view(context, request)
  File "/Users/marca/python/virtualenvs/kotti_inventorysvc/lib/python2.7/site-packages/kotti_navigation/views.py", line 125, in navigation_widget
    items = get_children(root, request)
  File "/Users/marca/python/virtualenvs/kotti_inventorysvc/lib/python2.7/site-packages/kotti_navigation/views.py", line 26, in get_children
    if c.in_navigation and c.__class__ not in ex_cts]
TypeError: 'in <string>' requires string as left operand, not DeclarativeMeta

 - Expression: "page_slots.left"
 - Filename:   ... marca/dev/git-repos/Kotti/kotti/templates/view/master.pt
 - Location:   (line 40: col 28)
 - Source:     tal:condition="page_slots.left"
                              ^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               renderer_name: kotti:templates/view/document.pt
               req: <Request - at 0x1090ce190>
               request: <Request - at 0x1090ce190>
               renderer_info: <RendererHelper - at 0x107a65a10>
               api: <TemplateAPI - at 0x1091024d0>
               context: <Host my_host at 0x1090e2ad0>
               view: <function view at 0x106cd07d0>
```