### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py26, py27
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+    webtest
+    wsgi_intercept<0.6
+    zope.testbrowser<4
+commands =
+    py.test {posargs:kotti_navigation/tests/}


### PR DESCRIPTION
```
$ pip install tox
...
$ tox
...
ERROR:   py26: commands failed
ERROR:   py27: commands failed
```