### PR TITLE
Add templates to package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.txt
+recursive-include kotti_navigation *.css *.js *.pt

--- a/kotti_navigation/locale/__init__.py
+++ b/kotti_navigation/locale/__init__.py
@@ -1,0 +1,1 @@
+# Just so that locale directory gets packaged and created on installation

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(name='kotti_navigation',
       url='http://pypi.python.org/pypi/kotti_navigation',
       license='BSD-derived (http://www.repoze.org/LICENSE.txt)',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+      package_data ={'kotti_navigation': ['templates/*.pt']},
       include_package_data=True,
       zip_safe=False,
       install_requires=[


### PR DESCRIPTION
Without this, I think templates don't get bundled in the sdist

```
$ tar tvzf dist/kotti_navigation-0.3dev-r0.tar.gz | grep template
<nothing>
```
