### PR TITLE
setup.py: Make version PEP-440-compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ long_description = (
 
 
 setup(name='kotti_navigation',
-      version='0.4b1dev',
+      version='0.4b1.dev0',
       description="""Add a configurable navigation to your Kotti site""",
       long_description=long_description,
       classifiers=[


### PR DESCRIPTION
Prevents this warning when installing:

```
    /Users/marca/python/virtualenvs/kotti_inventorysvc/lib/python2.7/site-packages/setuptools/dist.py:289: UserWarning: The version specified requires normalization, consider using '0.4b1.dev0' instead of '0.4b1dev'.
```