### PR TITLE
Fix #12: c.__class__ => c.__class__.__name__

### DIFF
--- a/kotti_navigation/util.py
+++ b/kotti_navigation/util.py
@@ -40,10 +40,10 @@ def _check_children(request, location, children):
         children = [c for c in children if c.in_navigation]
     if content_types_to_include:
         children = [c for c in children
-                    if str(c.__class__) in content_types_to_include]
+                    if str(c.__class__.__name__) in content_types_to_include]
     if content_types_to_exclude:
         children = [c for c in children
-                    if str(c.__class__) not in content_types_to_exclude]
+                    if str(c.__class__.__name__) not in content_types_to_exclude]
     return children
 
 


### PR DESCRIPTION
Prevents the error in #12:

```pytb
TypeError: 'in <string>' requires string as left operand, not DeclarativeMeta

 - Expression: "page_slots.left"
 - Filename:   ... marca/dev/git-repos/Kotti/kotti/templates/view/master.pt
 - Location:   (line 40: col 28)
 - Source:     tal:condition="page_slots.left"
                              ^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               renderer_name: kotti:templates/view/document.pt
               req: <Request - at 0x1090ce190>
               request: <Request - at 0x1090ce190>
               renderer_info: <RendererHelper - at 0x107a65a10>
               api: <TemplateAPI - at 0x1091024d0>
               context: <Host my_host at 0x1090e2ad0>
               view: <function view at 0x106cd07d0>
```